### PR TITLE
Directly return the new Client API Key

### DIFF
--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -74,7 +74,7 @@ def test_endpoint_test(api):
 
 
 def test_endpoint_get_client_key(api):
-    req = api.get_client_key(user_id=1234)
+    req = api._get_client_key(user_id=1234)
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/client-key'
     assert req.body == '{"user_id": "1234"}'

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -77,7 +77,7 @@ class YesGraphAPI(object):
 
         Documentation - https://www.yesgraph.com/docs/#obtaining-a-client-api-key
         """
-        return self._request('POST', '/client-key', {'user_id': str(user_id)})
+        return self._request('POST', '/client-key', {'user_id': str(user_id)})['client_api_key']
 
     def get_address_book(self, user_id):
         """

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -71,13 +71,16 @@ class YesGraphAPI(object):
         """
         return self._request('GET', '/test')
 
+    def _get_client_key(self, user_id):
+        return self._request('POST', '/client-key', {'user_id': str(user_id)})
+
     def get_client_key(self, user_id):
         """
         Wrapped method for POST of /client-key endpoint
 
         Documentation - https://www.yesgraph.com/docs/#obtaining-a-client-api-key
         """
-        return self._request('POST', '/client-key', {'user_id': str(user_id)})['client_api_key']
+        return self._get_client_key(user_id)['client_api_key']
 
     def get_address_book(self, user_id):
         """


### PR DESCRIPTION
This changes the `.get_client_key()` method to directly return the client key (so a string, not the entire dict). Yes, this _does_ make this endpoint somewhat less consistent from the others, but since this is an "internal" endpoint, this may not be as bad as it sounds. Not changing this makes the method rather tedious to work with.
