### PR TITLE
Make source key optional for `post_google`

### DIFF
--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -269,12 +269,31 @@ def test_endpoint_post_facebook(api):
 def test_endpoint_post_google(api):
     sentinel = {'dummy': 'payload'}
 
-    req = api.post_google(user_id=1234, payload=sentinel, source_type='gmail')
+    req = api.post_google(user_id=1234, payload=sentinel)
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/google'
 
     assert json.loads(req.body) == {
         'user_id': '1234',
-        'source': {'type': 'gmail'},
+        'payload': sentinel,
+    }
+
+    req = api.post_google(user_id=1234, payload=sentinel, source_name='Jon Snow')
+    assert req.method == 'POST'
+    assert req.url == 'https://api.yesgraph.com/v0/google'
+
+    assert json.loads(req.body) == {
+        'user_id': '1234',
+        'source': {'name': 'Jon Snow'},
+        'payload': sentinel,
+    }
+
+    req = api.post_google(user_id=1234, payload=sentinel, source_email='jon@stark.net')
+    assert req.method == 'POST'
+    assert req.url == 'https://api.yesgraph.com/v0/google'
+
+    assert json.loads(req.body) == {
+        'user_id': '1234',
+        'source': {'email': 'jon@stark.net', 'type': 'gmail:jon@stark.net'},
         'payload': sentinel,
     }

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -217,14 +217,20 @@ class YesGraphAPI(object):
 
         Documentation - https://www.yesgraph.com/docs/reference#post-google
         """
-        if source_name:
-            source['name'] = source_name
-        if source_email:
-            source['email'] = source_email
-
         data = {
             'user_id': str(user_id),
-            'source': source,
             'payload': payload,
         }
+
+        if any(source_name, source_email):
+            source = {}
+
+            if source_name:
+                source['name'] = source_name
+            if source_email:
+                source['email'] = source_email
+                source['type'] = 'gmail:{}'.format(source_email)
+
+            data['source'] = source
+
         return self._request('POST', '/google', data)

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -222,7 +222,7 @@ class YesGraphAPI(object):
             'payload': payload,
         }
 
-        if any(source_name, source_email):
+        if any([source_name, source_email]):
             source = {}
 
             if source_name:

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -211,16 +211,12 @@ class YesGraphAPI(object):
         """
         return self._request('GET', '/facebook/{0}'.format(quote_plus(str(user_id))))
 
-    def post_google(self, user_id, payload, source_type, source_name=None,
-                    source_email=None):
+    def post_google(self, user_id, payload, source_name=None, source_email=None):
         """
         Wrapped method for POST of /google endpoint
 
         Documentation - https://www.yesgraph.com/docs/reference#post-google
         """
-        source = {
-            'type': source_type,
-        }
         if source_name:
             source['name'] = source_name
         if source_email:

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -229,7 +229,7 @@ class YesGraphAPI(object):
                 source['name'] = source_name
             if source_email:
                 source['email'] = source_email
-                source['type'] = 'gmail:{}'.format(source_email)
+                source['type'] = 'gmail:{0}'.format(source_email)
 
             data['source'] = source
 

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -215,7 +215,7 @@ class YesGraphAPI(object):
         """
         Wrapped method for POST of /google endpoint
 
-        Documentation - https://www.yesgraph.com/docs/reference#post-google
+        Documentation - https://www.yesgraph.com/docs/reference#post-address-bookgoogle
         """
         data = {
             'user_id': str(user_id),


### PR DESCRIPTION
#### What's this PR do?
This changes creation of the source dictionary to be dependent on the user making use of either the `source_name` or `source_email` kwargs.

#### Any background context you want to provide?
The `/address-book/google` endpoint changed to make the `source` key optional.


#### What are the relevant tickets?
https://app.asana.com/0/24917946732380/30762917586160