### PR TITLE
Deprecate invitee type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+0.5
+- Deprecate the `invitee_id` and `invitee_type` fields in the Invites API
+  endpoints
+- Require keyword arguments for the Invites API endpoints
+
 0.4.2
 - Set User-Agent header
 

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -146,23 +146,28 @@ def test_endpoint_post_address_book_with_source_info(api):
 
 def test_endpoint_post_invite_sent(api):
     # Simplest invocation
-    req = api.post_invite_sent(user_id=42, invitee_id='john.smith@gmail.com')
+    req = api.post_invite_sent(user_id=42, email='john.smith@gmail.com')
 
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/invite-sent'
 
     assert json.loads(req.body) == {
         'user_id': '42',
-        'invitee_type': 'email',
-        'invitee_id': 'john.smith@gmail.com',
+        'email': 'john.smith@gmail.com',
+    }
+
+    # Deprecated API call (remove this test when we drop support for this)
+    req = api.post_invite_sent(user_id=42, invitee_id='john.smith@gmail.com')
+    assert json.loads(req.body) == {
+        'user_id': '42',
+        'email': 'john.smith@gmail.com',
     }
 
 
 def test_endpoint_post_invite_sent_advanced(api):
     # Invocation with advanced (optional params)
     now = datetime(2015, 3, 19, 13, 37, 00)
-    req = api.post_invite_sent(user_id=1234, invitee_id='555-123000',
-                               invitee_type='phone', sent_at=now)
+    req = api.post_invite_sent(user_id=1234, phone='555-123000', sent_at=now)
 
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/invite-sent'
@@ -170,28 +175,42 @@ def test_endpoint_post_invite_sent_advanced(api):
     assert json.loads(req.body) == {
         'sent_at': '2015-03-19T13:37:00',
         'user_id': '1234',
-        'invitee_type': 'phone',
-        'invitee_id': '555-123000',
+        'phone': '555-123000',
+    }
+
+    # Deprecated API call (remove this test when we drop support for this)
+    req = api.post_invite_sent(user_id=1234, invitee_id='555-123000',
+                               invitee_type='phone', sent_at=now)
+
+    assert json.loads(req.body) == {
+        'sent_at': '2015-03-19T13:37:00',
+        'user_id': '1234',
+        'phone': '555-123000',
     }
 
 
 def test_endpoint_post_invite_accepted(api):
     # Simplest invocation
-    req = api.post_invite_accepted('john.smith@gmail.com')
+    req = api.post_invite_accepted(email='john.smith@gmail.com')
 
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/invite-accepted'
 
     assert json.loads(req.body) == {
-        'invitee_type': 'email',
-        'invitee_id': 'john.smith@gmail.com',
+        'email': 'john.smith@gmail.com',
+    }
+
+    # Deprecated API call (remove this test when we drop support for this)
+    req = api.post_invite_accepted(invitee_id='john.smith@gmail.com')
+    assert json.loads(req.body) == {
+        'email': 'john.smith@gmail.com',
     }
 
 
 def test_endpoint_post_invite_accepted_advanced(api):
     # Invocation with advanced (optional params)
     now = datetime(2015, 3, 19, 13, 37, 00)
-    req = api.post_invite_accepted('555-123000', invitee_type='phone',
+    req = api.post_invite_accepted(phone='555-123000',
                                    accepted_at=now, new_user_id=42)
 
     assert req.method == 'POST'
@@ -199,8 +218,17 @@ def test_endpoint_post_invite_accepted_advanced(api):
 
     assert json.loads(req.body) == {
         'accepted_at': '2015-03-19T13:37:00',
-        'invitee_type': 'phone',
-        'invitee_id': '555-123000',
+        'phone': '555-123000',
+        'new_user_id': '42',
+    }
+
+    # Deprecated API call (remove this test when we drop support for this)
+    req = api.post_invite_accepted(invitee_id='555-123000', invitee_type='phone',
+                                   accepted_at=now, new_user_id=42)
+
+    assert json.loads(req.body) == {
+        'accepted_at': '2015-03-19T13:37:00',
+        'phone': '555-123000',
         'new_user_id': '42',
     }
 

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -8,7 +8,7 @@ from requests import Request, Session
 
 from six.moves.urllib.parse import quote_plus
 
-__version__ = '0.4.2'
+__version__ = '0.5dev0'
 
 
 def deprecation(message):

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -155,7 +155,7 @@ class YesGraphAPI(object):
             invitee_type = kwargs.get('invitee_type', 'email')
             if invitee_type == 'email' and not email:
                 email = str(invitee_id)
-            elif invitee_type in {'sms', 'phone'} and not phone:
+            elif invitee_type in ('sms', 'phone') and not phone:
                 phone = str(invitee_id)
             else:
                 raise ValueError('Unknown invitee_type: {}'.format(invitee_type))
@@ -193,7 +193,7 @@ class YesGraphAPI(object):
             invitee_type = kwargs.get('invitee_type', 'email')
             if invitee_type == 'email' and not email:
                 email = str(invitee_id)
-            elif invitee_type in {'sms', 'phone'} and not phone:
+            elif invitee_type in ('sms', 'phone') and not phone:
                 phone = str(invitee_id)
             else:
                 raise ValueError('Unknown invitee_type: {}'.format(invitee_type))


### PR DESCRIPTION
This deprecates the `invitee_type` and `invitee_id` fields in our Invite API. The `.post_invite_sent()` and `.post_invite_accepted()` methods now require the use of keyword arguments, so this is a backwards-incompatible change, bumping the version number to the 0.5 range.

Code that still uses the `invitee_id` and `invitee_type` keyword arguments will still work, but a deprecation message is printed.