### PR TITLE
Add Batch Invites Sent and Accepted, and Suggested Seen endpoints

### DIFF
--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -17,6 +17,7 @@ class SafeYesGraphAPI(YesGraphAPI):
         inspection.
         """
         prepped_req = self._prepare_request(method, endpoint, data=data, **url_args)
+
         return prepped_req
 
 
@@ -95,7 +96,7 @@ def test_endpoint_get_client_key(api):
     req = api._get_client_key(user_id=1234)
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/client-key'
-    assert req.body == '{"user_id": "1234"}'
+    assert req.body == 'user_id=1234'
 
 
 def test_endpoint_get_address_book(api):
@@ -242,15 +243,16 @@ def test_endpoint_get_users(api):
 
 
 def test_endpoint_post_users(api):
-    USERS = [
+    USERS = {'entries': [
         {'id': 1, 'name': 'John Smith', 'email': 'john.smith@gmail.com'},
         {'id': 2, 'name': 'Jane Doe', 'email': 'jane.doe@gmail.com'},
-    ]
+    ]}
 
     req = api.post_users(USERS)
 
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/users'
+
     assert json.loads(req.body) == USERS
 
 
@@ -299,6 +301,19 @@ def test_endpoint_post_facebook(api):
     # Simplest invocation (without user_id info)
     FRIENDS = [
         {"id": "10000012345", "name": "John Doe"},
+        {"id": "10000012389", "name": "Jane Borger"},
+    ]
+    req = api.post_facebook(friends=FRIENDS, source_id=1234)
+    assert req.method == 'POST'
+    assert req.url == 'https://api.yesgraph.com/v0/facebook'
+
+    assert json.loads(req.body) == {
+        'self': {'id': 1234},
+        'friends': FRIENDS,
+    }
+
+    # Simplest invocation (without user_id info)
+    FRIENDS = [
         {"id": "10000012389", "name": "Jane Borger"},
     ]
     req = api.post_facebook(friends=FRIENDS, source_id=1234)

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -145,17 +145,65 @@ def test_endpoint_post_address_book_with_source_info(api):
     }
 
 
-def test_endpoint_post_invite_sent(api):
-    # Simplest invocation
-    req = api.post_invite_sent(user_id=42, email='john.smith@gmail.com')
+def test_endpoint_post_suggested_seen(api):
+    entries = [
+        {'user_id': '1229',
+         'name': 'John Doe',
+         'phones': ['+1 4442223333', '+1 555-222-1234'],
+         'seen_at': '2015-03-28T20:16:12+00:00'
+         },
+        {'user_id': '1234',
+         'name': 'Jean Doe',
+         'emails': ['abigail.kirigin@gmail.com'],
+         'seen_at': '2015-03-28T20:16:12+00:00'
+         },
+        {'user_id': '5678',
+         'name': 'Jane Doe',
+         'phones': ['+1 555 222 3333', '+1 555 222 3331'],
+         'seen_at':'2015-02-28T20:16:12+00:00'
+         },
+        {'user_id': '5678',
+         'phones': ['+1 555-999-1234'],
+         'seen_at': '2015-01-28T20:16:12+00:00'
+         }
+    ]
+
+    req = api.post_suggested_seen(entries=entries)
 
     assert req.method == 'POST'
-    assert req.url == 'https://api.yesgraph.com/v0/invite-sent'
+    assert req.url == 'https://api.yesgraph.com/v0/suggested-seen'
+    assert json.loads(req.body) == {'entries': entries}
 
-    assert json.loads(req.body) == {
-        'user_id': '42',
-        'email': 'john.smith@gmail.com',
-    }
+
+def test_endpoint_post_invites_sent(api):
+    entries = [
+        {'user_id': '1229',
+         'invitee_name': 'John Doe',
+         'phone': '+1 555 222 3333',
+         'sent_at': '2015-03-28T20:16:12+00:00'
+         },
+        {'user_id': '1234',
+         'invitee_name': 'Jane Doe',
+         'email': 'jane@yesgraph.com',
+         'phone': '+1 555 222 2222',
+         'sent_at': '2015-03-28T20:16:12+00:00'
+         },
+        {'user_id': '5678',
+         'invitee_name': 'Jean Doe',
+         'phone': '+1 555 222 1111',
+         'sent_at': '2015-02-28T20:16:12+00:00'
+         },
+        {'user_id': '5678',
+         'phone': '+1 555 222 5555',
+         'sent_at': '2015-01-28T20:16:12+00:00'
+         }
+    ]
+
+    req = api.post_invites_sent(entries=entries)
+
+    assert req.method == 'POST'
+    assert req.url == 'https://api.yesgraph.com/v0/invites-sent'
+    assert json.loads(req.body) == {'entries': entries}
 
     # Deprecated API call (remove this test when we drop support for this)
     req = api.post_invite_sent(user_id=42, invitee_id='john.smith@gmail.com')
@@ -191,15 +239,35 @@ def test_endpoint_post_invite_sent_advanced(api):
 
 
 def test_endpoint_post_invite_accepted(api):
-    # Simplest invocation
-    req = api.post_invite_accepted(email='john.smith@gmail.com')
+    entries = [
+        {'new_user_id': '1229',
+         'name': 'John Doe',
+         'phone': '+1 555 222 3333',
+         'accepted_at': '2015-03-28T20:16:12+00:00'
+         },
+        {'new_user_id': '1234',
+         'name': 'Jane Doe',
+         'email': 'jane@yesgraph.com',
+         'phone': '+1 555 222 2222',
+         'accepted_at': '2015-03-28T20:16:12+00:00'
+         },
+        {'new_user_id': '5678',
+         'name': 'Jean Doe',
+         'phone': '+1 555 222 1111',
+         'accepted_at': '2015-02-28T20:16:12+00:00'
+         },
+        {'new_user_id': '5678',
+         'phone': '+1 555 222 5555',
+         'accepted_at': '2015-01-28T20:16:12+00:00'
+         }
+    ]
+
+    req = api.post_invites_accepted(entries=entries)
 
     assert req.method == 'POST'
-    assert req.url == 'https://api.yesgraph.com/v0/invite-accepted'
+    assert req.url == 'https://api.yesgraph.com/v0/invites-accepted'
 
-    assert json.loads(req.body) == {
-        'email': 'john.smith@gmail.com',
-    }
+    assert json.loads(req.body) == {'entries': entries}
 
     # Deprecated API call (remove this test when we drop support for this)
     req = api.post_invite_accepted(invitee_id='john.smith@gmail.com')

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -2,6 +2,7 @@ import platform
 import warnings
 from collections import Iterable
 from datetime import datetime
+import json
 
 import six
 from requests import Request, Session
@@ -61,14 +62,10 @@ class YesGraphAPI(object):
 
         url = self._build_url(endpoint, limit=limit)
 
-        # Prepare the data
-        if data is not None:
-            if not is_nonstring_iterable(data):
-                msg = 'Argument "data" must be (non-string) iterable, got: {0!r}'
-                raise TypeError(msg.format(data))  # pragma: no cover  # noqa
+        req = Request(method, url, data=data, headers=headers)
 
-        req = Request(method, url, json=data, headers=headers)
         prepped_req = self.session.prepare_request(req)
+
         return prepped_req
 
     def _request(self, method, endpoint, data=None, **url_args):  # pragma: no cover
@@ -76,6 +73,7 @@ class YesGraphAPI(object):
         Builds, prepares, and sends the complete request to the YesGraph API,
         returning the decoded response.
         """
+
         prepped_req = self._prepare_request(method, endpoint, data=data, **url_args)
         resp = self.session.send(prepped_req)
         return self._handle_response(resp)
@@ -134,6 +132,9 @@ class YesGraphAPI(object):
             'source': source,
             'entries': entries,
         }
+
+        data = json.dumps(data)
+
         return self._request('POST', '/address-book', data)
 
     def post_invite_accepted(self, **kwargs):
@@ -173,6 +174,8 @@ class YesGraphAPI(object):
         if new_user_id:
             data['new_user_id'] = str(new_user_id)
 
+        data = json.dumps(data)
+
         return self._request('POST', '/invite-accepted', data)
 
     def post_invites_accepted(self, **kwargs):
@@ -184,10 +187,12 @@ class YesGraphAPI(object):
 
         entries = kwargs.get('entries', None)
 
-        if entries:
+        if entries and type(entries) == list:
             data = {'entries': entries}
         else:
             raise ValueError('An entry list is required')
+
+        data = json.dumps(data)
 
         return self._request('POST', '/invites-accepted', data)
 
@@ -228,6 +233,8 @@ class YesGraphAPI(object):
         if sent_at:
             data['sent_at'] = format_date(sent_at)
 
+        data = json.dumps(data)
+
         return self._request('POST', '/invite-sent', data)
 
     def post_invites_sent(self, **kwargs):
@@ -244,7 +251,9 @@ class YesGraphAPI(object):
         else:
             raise ValueError('An entry list is required')
 
-        return self._request('POST', '/invites-sent', data)
+        data = json.dumps(data)
+
+        return self._request('POST', '/invites-sent', data=data)
 
     def post_suggested_seen(self, **kwargs):
         """
@@ -260,7 +269,9 @@ class YesGraphAPI(object):
         else:
             raise ValueError('An entry list is required')
 
-        return self._request('POST', '/suggested-seen', data)
+        data = json.dumps(data)
+
+        return self._request('POST', '/suggested-seen', data=data)
 
     def get_users(self):
         """
@@ -276,7 +287,10 @@ class YesGraphAPI(object):
 
         Documentation - https://www.yesgraph.com/docs/reference#post-users
         """
-        return self._request('POST', '/users', users)
+
+        data = json.dumps(users)
+
+        return self._request('POST', '/users', data=data)
 
     def get_address_books(self, limit=None):
         """
@@ -307,7 +321,9 @@ class YesGraphAPI(object):
         if user_id:
             data['user_id'] = user_id
 
-        return self._request('POST', '/facebook', data)
+        data = json.dumps(data)
+
+        return self._request('POST', '/facebook', data=data)
 
     def get_facebook(self, user_id):
         """

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -175,6 +175,22 @@ class YesGraphAPI(object):
 
         return self._request('POST', '/invite-accepted', data)
 
+    def post_invites_accepted(self, **kwargs):
+        """
+        Wrapped method for POST of /invites-accepted endpoint
+
+        Documentation - https://www.yesgraph.com/docs/reference#post-invites-accepted
+        """
+
+        entries = kwargs.get('entries', None)
+
+        if entries:
+            data = {'entries': entries}
+        else:
+            raise ValueError('An entry list is required')
+
+        return self._request('POST', '/invites-accepted', data)
+
     def post_invite_sent(self, user_id, **kwargs):
         """
         Wrapped method for POST of /invite-sent endpoint
@@ -213,6 +229,38 @@ class YesGraphAPI(object):
             data['sent_at'] = format_date(sent_at)
 
         return self._request('POST', '/invite-sent', data)
+
+    def post_invites_sent(self, **kwargs):
+        """
+        Wrapped method for POST of /invites-sent endpoint
+
+        Documentation - https://www.yesgraph.com/docs/reference#post-invites-sent
+        """
+
+        entries = kwargs.get('entries', None)
+
+        if entries:
+            data = {'entries': entries}
+        else:
+            raise ValueError('An entry list is required')
+
+        return self._request('POST', '/invites-sent', data)
+
+    def post_suggested_seen(self, **kwargs):
+        """
+        Wrapped method for POST of /invites-accepted endpoint
+
+        Documentation - https://www.yesgraph.com/docs/reference#post-invites-accepted
+        """
+
+        entries = kwargs.get('entries', None)
+
+        if entries:
+            data = {'entries': entries}
+        else:
+            raise ValueError('An entry list is required')
+
+        return self._request('POST', '/suggested-seen', data)
 
     def get_users(self):
         """


### PR DESCRIPTION
#### What's this PR do?
This adds endpoints for Invites Sent and Accepted, and also adds the Suggested Seen endpoint. Also, to support the newer version of the Requests module, data is converted to JSON before passing it to Requests.

#### Where should the reviewer start?
Review the code for the above items.

#### How should this be manually tested?
This can be tested by running tox, and also by running test scripts from the YesGraph documentation.

#### Any background context you want to provide?
The Invites Sent and Invites Suggested should be made to handle batch requests to be more consistent with the rest of the API.
