### PR TITLE
Update to add limit to AddressBook POST to limit number of returned rows

### DIFF
--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -116,7 +116,7 @@ def test_endpoint_post_address_book(api):
         {'name': 'Foo', 'email': 'foo@example.org'},
         {'name': 'Bar', 'email': 'bar@example.org'},
     ]
-    req = api.post_address_book(user_id=1234, entries=ENTRIES, source_type='gmail')
+    req = api.post_address_book(user_id=1234, entries=ENTRIES, source_type='gmail', limit=20)
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/address-book'
 
@@ -124,6 +124,7 @@ def test_endpoint_post_address_book(api):
         'user_id': '1234',
         'source': {'type': 'gmail'},
         'entries': ENTRIES,
+        'limit': 20
     }
 
 
@@ -142,6 +143,7 @@ def test_endpoint_post_address_book_with_source_info(api):
         'user_id': '1234',
         'source': {'type': 'ios', 'name': 'Mr. Test', 'email': 'test@example.org'},
         'entries': ENTRIES,
+        'limit': None
     }
 
 

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -113,7 +113,7 @@ class YesGraphAPI(object):
         return self._request('GET', endpoint, limit=limit)
 
     def post_address_book(self, user_id, entries,
-                          source_type, source_name=None, source_email=None):
+                          source_type, source_name=None, source_email=None, limit=None):
         """
         Wrapped method for POST of /address-book endpoint
 
@@ -127,10 +127,14 @@ class YesGraphAPI(object):
         if source_email:
             source['email'] = source_email
 
+        if limit is not None:
+            assert(type(limit) == int)
+
         data = {
             'user_id': str(user_id),
             'source': source,
             'entries': entries,
+            'limit': limit
         }
 
         data = json.dumps(data)


### PR DESCRIPTION
#### What's this PR do?
This updates the SDK to allow a "limit" item to be added to the AddressBook POST.

#### Where should the reviewer start?
Review the method post_address_book in yesgraph.py

#### How should this be manually tested?
Run tox

#### Any background context you want to provide?
This is an addition to an enhancement previously made, to rank addressbooks upon POST.

#### Questions:
- Is there a blog post?
Not yet. There will be.

- Does the knowledge base need an update?
Yes, we need to update the docs

