### PR TITLE
Removing GET request from /users endpoint

### DIFF
--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -319,14 +319,6 @@ def test_endpoint_post_invite_accepted_advanced(api):
     }
 
 
-def test_endpoint_get_users(api):
-    req = api.get_users()
-
-    assert req.method == 'GET'
-    assert req.url == 'https://api.yesgraph.com/v0/users'
-    assert req.body is None
-
-
 def test_endpoint_post_users(api):
     USERS = {'entries': [
         {'id': 1, 'name': 'John Smith', 'email': 'john.smith@gmail.com'},

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -284,14 +284,6 @@ class YesGraphAPI(object):
 
         return self._request('POST', '/suggested-seen', data=data)
 
-    def get_users(self):
-        """
-        Wrapped method for GET of /users endpoint
-
-        Documentation - https://www.yesgraph.com/docs/reference#get-users
-        """
-        return self._request('GET', '/users')
-
     def post_users(self, users):
         """
         Wrapped method for POST of users endpoint


### PR DESCRIPTION
#### What’s this PR do?
This removes the GET request for the /users endpoint, since the API support for GET has been disabled.

#### Where should the reviewer start?
Review the code and test it out

#### How should this be manually tested?
Run tox

#### What are the relevant tickets?
https://app.asana.com/0/49674024563363/81729433038721

#### Questions:
- Is there a blog post?
- Does the knowledge base need an update?
Yes, Readme updated