### PR TITLE
Add get followers endpoint

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-pro
+repo_token: zGDeeP21JYP4bHrSvMJxQUJoL3TQYZ8iJ

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - pip install tox
 
 script:
-  - tox
+  - tox -e travis
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
     - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
   matrix:
-    - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py33
     - TOXENV=py34

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,15 @@ language: python
 
 python: 2.7
 
+# To enable containerized (Docker) Travis builds, might be faster
+sudo: false
+
 env:
   global:
     # configure pip caches
     - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
+    - COVERALLS_REPO_TOKEN=zGDeeP21JYP4bHrSvMJxQUJoL3TQYZ8iJ
   matrix:
     - TOXENV=py27
     - TOXENV=py33

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Python YesGraph
 
 [![Build Status](https://travis-ci.org/YesGraph/python-yesgraph.svg)](https://travis-ci.org/YesGraph/python-yesgraph)
+[![Coverage Status](https://coveralls.io/repos/github/YesGraph/python-yesgraph/badge.svg?branch=master&t=07x025)](https://coveralls.io/github/YesGraph/python-yesgraph?branch=master)
 
 Python wrapper for the YesGraph API.
 

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -284,11 +284,11 @@ def test_endpoint_get_followers(api):
     phone = "555-111-2222"
 
     req = api.get_followers(type_name='user_id', identifier=user_id)
-    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}/'.format('user_id', user_id)
+    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}'.format('user_id', user_id)
     req = api.get_followers(type_name='email', identifier=email)
-    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}/'.format('email', email)
+    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}'.format('email', email)
     req = api.get_followers(type_name='phone', identifier=phone)
-    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}/'.format('phone', phone)
+    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}'.format('phone', phone)
     assert req.method == 'GET'
 
 

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -231,40 +231,8 @@ def test_endpoint_post_invites_sent(api):
     assert req.url == 'https://api.yesgraph.com/v0/invites-sent'
     assert json.loads(req.body) == {'entries': entries}
 
-    # Deprecated API call (remove this test when we drop support for this)
-    req = api.post_invite_sent(user_id=42, invitee_id='john.smith@gmail.com')
-    assert json.loads(req.body) == {
-        'user_id': '42',
-        'email': 'john.smith@gmail.com',
-    }
 
-
-def test_endpoint_post_invite_sent_advanced(api):
-    # Invocation with advanced (optional params)
-    now = datetime(2015, 3, 19, 13, 37, 00)
-    req = api.post_invite_sent(user_id=1234, phone='555-123000', sent_at=now)
-
-    assert req.method == 'POST'
-    assert req.url == 'https://api.yesgraph.com/v0/invite-sent'
-
-    assert json.loads(req.body) == {
-        'sent_at': '2015-03-19T13:37:00',
-        'user_id': '1234',
-        'phone': '555-123000',
-    }
-
-    # Deprecated API call (remove this test when we drop support for this)
-    req = api.post_invite_sent(user_id=1234, invitee_id='555-123000',
-                               invitee_type='phone', sent_at=now)
-
-    assert json.loads(req.body) == {
-        'sent_at': '2015-03-19T13:37:00',
-        'user_id': '1234',
-        'phone': '555-123000',
-    }
-
-
-def test_endpoint_post_invite_accepted(api):
+def test_endpoint_post_invites_accepted(api):
     entries = [
         {'new_user_id': '1229',
          'name': 'John Doe',
@@ -295,38 +263,6 @@ def test_endpoint_post_invite_accepted(api):
 
     assert json.loads(req.body) == {'entries': entries}
 
-    # Deprecated API call (remove this test when we drop support for this)
-    req = api.post_invite_accepted(invitee_id='john.smith@gmail.com')
-    assert json.loads(req.body) == {
-        'email': 'john.smith@gmail.com',
-    }
-
-
-def test_endpoint_post_invite_accepted_advanced(api):
-    # Invocation with advanced (optional params)
-    now = datetime(2015, 3, 19, 13, 37, 00)
-    req = api.post_invite_accepted(phone='555-123000',
-                                   accepted_at=now, new_user_id=42)
-
-    assert req.method == 'POST'
-    assert req.url == 'https://api.yesgraph.com/v0/invite-accepted'
-
-    assert json.loads(req.body) == {
-        'accepted_at': '2015-03-19T13:37:00',
-        'phone': '555-123000',
-        'new_user_id': '42',
-    }
-
-    # Deprecated API call (remove this test when we drop support for this)
-    req = api.post_invite_accepted(invitee_id='555-123000', invitee_type='phone',
-                                   accepted_at=now, new_user_id=42)
-
-    assert json.loads(req.body) == {
-        'accepted_at': '2015-03-19T13:37:00',
-        'phone': '555-123000',
-        'new_user_id': '42',
-    }
-
 
 def test_endpoint_post_users(api):
     USERS = {'entries': [
@@ -340,6 +276,20 @@ def test_endpoint_post_users(api):
     assert req.url == 'https://api.yesgraph.com/v0/users'
 
     assert json.loads(req.body) == USERS
+
+
+def test_endpoint_get_followers(api):
+    user_id = "1234"
+    email = "email@email.com"
+    phone = "555-111-2222"
+
+    req = api.get_followers(type_name='user_id', identifier=user_id)
+    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}/'.format('user_id', user_id)
+    req = api.get_followers(type_name='email', identifier=email)
+    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}/'.format('email', email)
+    req = api.get_followers(type_name='phone', identifier=phone)
+    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}/'.format('phone', phone)
+    assert req.method == 'GET'
 
 
 def test_response_success(api):
@@ -363,50 +313,3 @@ def test_response_with_error(api):
 
     with pytest.raises(HTTPError):
         api._handle_response(fake_http_response)
-
-
-def test_endpoint_get_address_books(api):
-    req = api.get_address_books()
-    assert req.method == 'GET'
-    assert req.url == 'https://api.yesgraph.com/v0/address-books'
-    assert req.body is None
-
-
-def test_endpoint_get_facebook(api):
-    req = api.get_facebook(user_id=1234)
-    assert req.method == 'GET'
-    assert req.url == 'https://api.yesgraph.com/v0/facebook/1234'
-    assert req.body is None
-
-    # Test URL unsafe arguments to methods
-    req = api.get_facebook(user_id='user/with?unsafe&chars=inthem')
-    assert req.url == 'https://api.yesgraph.com/v0/facebook/user%2Fwith%3Funsafe%26chars%3Dinthem'
-
-
-def test_endpoint_post_facebook(api):
-    # Simplest invocation (without user_id info)
-    FRIENDS = [
-        {"id": "10000012345", "name": "John Doe"},
-        {"id": "10000012389", "name": "Jane Borger"},
-    ]
-    req = api.post_facebook(friends=FRIENDS, source_id=1234)
-    assert req.method == 'POST'
-    assert req.url == 'https://api.yesgraph.com/v0/facebook'
-
-    assert json.loads(req.body) == {
-        'self': {'id': 1234},
-        'friends': FRIENDS,
-    }
-
-    # Simplest invocation (without user_id info)
-    FRIENDS = [
-        {"id": "10000012389", "name": "Jane Borger"},
-    ]
-    req = api.post_facebook(friends=FRIENDS, source_id=1234)
-    assert req.method == 'POST'
-    assert req.url == 'https://api.yesgraph.com/v0/facebook'
-
-    assert json.loads(req.body) == {
-        'self': {'id': 1234},
-        'friends': FRIENDS,
-    }

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -1,6 +1,4 @@
 import json
-from datetime import datetime
-
 from requests import HTTPError
 
 import pytest

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -198,6 +198,9 @@ def test_endpoint_post_suggested_seen(api):
     assert req.url == 'https://api.yesgraph.com/v0/suggested-seen'
     assert json.loads(req.body) == {'entries': entries}
 
+    with pytest.raises(ValueError):
+        req = api.post_suggested_seen(entries=None)
+
 
 def test_endpoint_post_invites_sent(api):
     entries = [
@@ -228,6 +231,9 @@ def test_endpoint_post_invites_sent(api):
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/invites-sent'
     assert json.loads(req.body) == {'entries': entries}
+
+    with pytest.raises(ValueError):
+        req = api.post_invites_sent(entries=None)
 
 
 def test_endpoint_post_invites_accepted(api):
@@ -261,6 +267,9 @@ def test_endpoint_post_invites_accepted(api):
 
     assert json.loads(req.body) == {'entries': entries}
 
+    with pytest.raises(ValueError):
+        req = api.post_invites_accepted(entries=None)
+
 
 def test_endpoint_post_users(api):
     USERS = {'entries': [
@@ -288,6 +297,15 @@ def test_endpoint_get_followers(api):
     req = api.get_followers(type_name='phone', identifier=phone)
     assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}'.format('phone', phone)
     assert req.method == 'GET'
+
+    with pytest.raises(ValueError):
+        req = api.get_followers(type_name='some_wrong_type', identifier=email)
+    with pytest.raises(ValueError):
+        req = api.get_followers(type_name='some_wrong_type2', identifier=email)
+    with pytest.raises(ValueError):
+        req = api.get_followers(type_name='email', identifier=None)
+    with pytest.raises(ValueError):
+        req = api.get_followers(type_name='phone', identifier=None)
 
 
 def test_response_success(api):

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH COVERALLS_REPO_TOKEN
 deps=
     pytest
     coverage
-    -egit+git://github.com/YesGraph/coveralls-python.git#egg=coveralls
+    coveralls
 commands=
     python -m coverage run --source yesgraph -m pytest --strict {posargs} tests
     python -m coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps=
     coverage
 
 [testenv:travis]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH COVERALLS_REPO_TOKEN
 deps=
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26, py27, py33, py34, pypy, flake8
+envlist=py27, py33, py34, pypy, flake8
 
 [pytest]
 addopts =

--- a/tox.ini
+++ b/tox.ini
@@ -17,14 +17,13 @@ deps=
     coverage
 
 [testenv:travis]
-commands=py.test {posargs}
 deps=
     pytest
     pytest-cov
     coverage
     -egit+git://github.com/YesGraph/coveralls-python.git#egg=coveralls
 commands=
-    python -m coverage run
+    python -m coverage run --source yesgraph -m pytest --strict {posargs} tests
     python -m coverage report -m
     python -m coverage html
     coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,16 @@
 [tox]
 envlist=py27, py33, py34, pypy, flake8
 
-[pytest]
-addopts =
-    --ignore=setup.py
-    --doctest-modules
-    --cov yesgraph
-    --cov-report term
-    --cov-report html
-
 [testenv]
 commands=py.test {posargs}
 deps=
     pytest
-    pytest-cov
     coverage
 
 [testenv:travis]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH COVERALLS_REPO_TOKEN
 deps=
     pytest
-    pytest-cov
     coverage
     -egit+git://github.com/YesGraph/coveralls-python.git#egg=coveralls
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -14,13 +14,20 @@ commands=py.test {posargs}
 deps=
     pytest
     pytest-cov
+    coverage
 
-[testenv:py26]
+[testenv:travis]
 commands=py.test {posargs}
 deps=
     pytest
     pytest-cov
-    argparse  # unbreak py.test on Travis
+    coverage
+    -egit+git://github.com/YesGraph/coveralls-python.git#egg=coveralls
+commands=
+    python -m coverage run
+    python -m coverage report -m
+    python -m coverage html
+    coveralls
 
 [testenv:flake8]
 basepython = python2.7

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -95,7 +95,7 @@ class YesGraphAPI(object):
         """
         Wrapped method for GET of /test endpoint
 
-        Documentation - https://www.yesgraph.com/docs/reference#get-test
+        Documentation - https://www.yesgraph.com/docs/test
         """
         return self._request('GET', '/test')
 
@@ -106,7 +106,7 @@ class YesGraphAPI(object):
         """
         Wrapped method for POST of /client-key endpoint
 
-        Documentation - https://www.yesgraph.com/docs/reference#obtaining-a-client-api-key
+        Documentation - https://docs.yesgraph.com/docs/create-client-keys
         """
         result = self._get_client_key(user_id)
         return result['client_key']
@@ -118,7 +118,7 @@ class YesGraphAPI(object):
         """
         Wrapped method for GET of /address-book endpoint
 
-        Documentation - https://www.yesgraph.com/docs/reference#get-address-bookuser_id
+        Documentation - https://www.yesgraph.com/docs/address-book
         """
 
         urlargs = {'filter_suggested_seen': filter_suggested_seen,
@@ -170,7 +170,7 @@ class YesGraphAPI(object):
         """
         Wrapped method for POST of /invites-accepted endpoint
 
-        Documentation - https://www.yesgraph.com/docs/reference#post-invites-accepted
+        Documentation - https://docs.yesgraph.com/docs/invites-accepted
         """
 
         entries = kwargs.get('entries', None)
@@ -188,7 +188,7 @@ class YesGraphAPI(object):
         """
         Wrapped method for POST of /invites-sent endpoint
 
-        Documentation - https://www.yesgraph.com/docs/reference#post-invites-sent
+        Documentation - https://docs.yesgraph.com/docs/invites-sent
         """
 
         entries = kwargs.get('entries', None)
@@ -206,7 +206,7 @@ class YesGraphAPI(object):
         """
         Wrapped method for POST of /invites-accepted endpoint
 
-        Documentation - https://www.yesgraph.com/docs/reference#post-invites-accepted
+        Documentation - https://docs.yesgraph.com/docs/suggested-seen
         """
 
         entries = kwargs.get('entries', None)
@@ -224,7 +224,7 @@ class YesGraphAPI(object):
         """
         Wrapped method for POST of users endpoint
 
-        Documentation - https://www.yesgraph.com/docs/reference#post-users
+        Documentation - https://docs.yesgraph.com/docs/users
         """
 
         data = json.dumps(users)
@@ -234,6 +234,8 @@ class YesGraphAPI(object):
     def get_followers(self, type_name, identifier):
         """
         Wrapped method for GET of /followers/<type>/<identifier>/
+
+        Documentation - https://docs.yesgraph.com/v0/docs/followerstypeidentifier
         """
         if type_name not in ['user_id', 'email', 'phone']:
             raise ValueError("type_name must be 'user_id', 'email', or 'phone'")

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -138,7 +138,7 @@ class YesGraphAPI(object):
         """
         Wrapped method for POST of /address-book endpoint
 
-        Documentation - https://www.yesgraph.com/docs/reference#post-address-book
+        Documentation - https://www.yesgraph.com/docs/address-book
         """
         source = {
             'type': source_type,
@@ -166,47 +166,6 @@ class YesGraphAPI(object):
 
         return self._request('POST', '/address-book', data)
 
-    def post_invite_accepted(self, **kwargs):
-        """
-        Wrapped method for POST of /invite-accepted endpoint
-
-        Documentation - https://www.yesgraph.com/docs/reference#post-invite-accepted
-        """
-        email = kwargs.get('email')
-        phone = kwargs.get('phone')
-        accepted_at = kwargs.get('accepted_at')
-        new_user_id = kwargs.get('new_user_id')
-
-        if 'invitee_id' in kwargs or 'invitee_type' in kwargs:
-            deprecation('invitee_id and invitee_type fields have been deprecated. '
-                        'Please use the `email` or `phone` fields instead.')
-
-            invitee_id = kwargs['invitee_id']
-            invitee_type = kwargs.get('invitee_type', 'email')
-            if invitee_type == 'email' and not email:
-                email = str(invitee_id)
-            elif invitee_type in ('sms', 'phone') and not phone:
-                phone = str(invitee_id)
-            else:
-                raise ValueError('Unknown invitee_type: {}'.format(invitee_type))
-
-        if not (email or phone):
-            raise ValueError('An `email` or `phone` key is required')
-
-        data = {}
-        if email:
-            data['email'] = email
-        if phone:
-            data['phone'] = phone
-        if accepted_at:
-            data['accepted_at'] = format_date(accepted_at)
-        if new_user_id:
-            data['new_user_id'] = str(new_user_id)
-
-        data = json.dumps(data)
-
-        return self._request('POST', '/invite-accepted', data)
-
     def post_invites_accepted(self, **kwargs):
         """
         Wrapped method for POST of /invites-accepted endpoint
@@ -224,47 +183,6 @@ class YesGraphAPI(object):
         data = json.dumps(data)
 
         return self._request('POST', '/invites-accepted', data)
-
-    def post_invite_sent(self, user_id, **kwargs):
-        """
-        Wrapped method for POST of /invite-sent endpoint
-
-        Documentation - https://www.yesgraph.com/docs/reference#post-invite-sent
-        """
-        email = kwargs.get('email')
-        phone = kwargs.get('phone')
-        sent_at = kwargs.get('sent_at')
-
-        if 'invitee_id' in kwargs or 'invitee_type' in kwargs:
-            deprecation('invitee_id and invitee_type fields have been deprecated. '
-                        'Please use the `email` or `phone` fields instead.')
-
-            invitee_id = kwargs['invitee_id']
-            invitee_type = kwargs.get('invitee_type', 'email')
-            if invitee_type == 'email' and not email:
-                email = str(invitee_id)
-            elif invitee_type in ('sms', 'phone') and not phone:
-                phone = str(invitee_id)
-            else:
-                raise ValueError('Unknown invitee_type: {}'.format(invitee_type))
-
-        if not (email or phone):
-            raise ValueError('An `email` or `phone` key is required')
-
-        data = {
-            'user_id': str(user_id),
-        }
-
-        if email:
-            data['email'] = email
-        if phone:
-            data['phone'] = phone
-        if sent_at:
-            data['sent_at'] = format_date(sent_at)
-
-        data = json.dumps(data)
-
-        return self._request('POST', '/invite-sent', data)
 
     def post_invites_sent(self, **kwargs):
         """
@@ -313,43 +231,15 @@ class YesGraphAPI(object):
 
         return self._request('POST', '/users', data=data)
 
-    def get_address_books(self, limit=None):
+    def get_followers(self, type_name, identifier):
         """
-        Wrapped method for GET of /address-books endpoint
-
-        Documentation - https://www.yesgraph.com/docs/reference#get-address-books
+        Wrapped method for GET of /followers/<type>/<identifier>/
         """
-        return self._request('GET', '/address-books', limit=limit)
+        if type_name not in ['user_id', 'email', 'phone']:
+            raise ValueError("type_name must be 'user_id', 'email', or 'phone'")
+        if not identifier:
+            raise ValueError("Must have a non-null identifier")
 
-    def post_facebook(self, friends, user_id=None, source_id=None,
-                      source_name=None):
-        """
-        Wrapped method for POST of /facebook endpoint
+        endpoint = '/followers/{0}/{1}/'.format(type_name, identifier)
 
-        Documentation - https://www.yesgraph.com/docs/reference#post-facebook
-        """
-        source = {}
-        if source_id:
-            source['id'] = source_id
-        if source_name:
-            source['name'] = source_name
-
-        data = {
-            'self': source,
-            'friends': friends,
-        }
-
-        if user_id:
-            data['user_id'] = user_id
-
-        data = json.dumps(data)
-
-        return self._request('POST', '/facebook', data=data)
-
-    def get_facebook(self, user_id):
-        """
-        Wrapped method for GET of /facebook endpoint
-
-        Documentation - https://www.yesgraph.com/docs/reference#get-facebookuser_id
-        """
-        return self._request('GET', '/facebook/{0}'.format(quote_plus(str(user_id))))
+        return self._request('GET', endpoint)

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -240,6 +240,6 @@ class YesGraphAPI(object):
         if not identifier:
             raise ValueError("Must have a non-null identifier")
 
-        endpoint = '/followers/{0}/{1}/'.format(type_name, identifier)
+        endpoint = '/followers/{0}/{1}'.format(type_name, identifier)
 
         return self._request('GET', endpoint)

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -1,6 +1,4 @@
 import platform
-import warnings
-from collections import Iterable
 from datetime import datetime
 import json
 
@@ -9,15 +7,7 @@ from requests import Request, Session
 
 from six.moves.urllib.parse import quote_plus
 
-__version__ = '0.5'
-
-
-def deprecation(message):
-    warnings.warn(message, DeprecationWarning, stacklevel=2)
-
-
-def is_nonstring_iterable(obj):
-    return isinstance(obj, Iterable) and not isinstance(obj, six.string_types)
+__version__ = '0.6.0'
 
 
 def format_date(obj):


### PR DESCRIPTION
This PR adds support for the GET `/followers/<type>/<identifier>` endpoint.

It also removes the deprecated singular endpoints:

* POST /invite-accepted/ (single-entry)
* POST /invite-sent/ (single-entry)
* POST /facebook
* GET  /address-books (multiple)

Documentation is available at: [https://docs.yesgraph.com/v0/docs/followerstypeidentifier](https://docs.yesgraph.com/v0/docs/followerstypeidentifier)