### PR TITLE
Add deprecated endpoints back in

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.6.1
+- Adds POST /invite-sent (single entry) and POST /invite-accepted (single entry) deprecated endpoints back in for compatibility
+- Updates tests
+
 0.6.0
 - Updates POST /invite-sent (single entry) to POST /invites-sent (list)
 - Updates POST /invite-accepted (single entry) to POST /invites-accepted (list)

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -1,4 +1,6 @@
 import json
+from datetime import datetime
+
 from requests import HTTPError
 
 import pytest
@@ -232,11 +234,40 @@ def test_endpoint_post_invites_sent(api):
     assert req.url == 'https://api.yesgraph.com/v0/invites-sent'
     assert json.loads(req.body) == {'entries': entries}
 
-    with pytest.raises(ValueError):
-        req = api.post_invites_sent(entries=None)
+    # Deprecated API call (remove this test when we drop support for this)
+    req = api.post_invite_sent(user_id=42, invitee_id='john.smith@gmail.com')
+    assert json.loads(req.body) == {'entries': [{
+        'user_id': '42',
+        'email': 'john.smith@gmail.com',
+    }]}
 
 
-def test_endpoint_post_invites_accepted(api):
+def test_endpoint_post_invite_sent_advanced(api):
+    # Invocation with advanced (optional params)
+    now = datetime(2015, 3, 19, 13, 37, 00)
+    req = api.post_invite_sent(user_id=1234, phone='555-123000', sent_at=now)
+
+    assert req.method == 'POST'
+    assert req.url == 'https://api.yesgraph.com/v0/invites-sent'
+
+    assert json.loads(req.body) == {'entries': [{
+        'sent_at': '2015-03-19T13:37:00',
+        'user_id': '1234',
+        'phone': '555-123000',
+    }]}
+
+    # Deprecated API call (remove this test when we drop support for this)
+    req = api.post_invite_sent(user_id=1234, invitee_id='555-123000',
+                               invitee_type='phone', sent_at=now)
+
+    assert json.loads(req.body) == {'entries': [{
+        'sent_at': '2015-03-19T13:37:00',
+        'user_id': '1234',
+        'phone': '555-123000',
+    }]}
+
+
+def test_endpoint_post_invite_accepted(api):
     entries = [
         {'new_user_id': '1229',
          'name': 'John Doe',
@@ -267,8 +298,37 @@ def test_endpoint_post_invites_accepted(api):
 
     assert json.loads(req.body) == {'entries': entries}
 
-    with pytest.raises(ValueError):
-        req = api.post_invites_accepted(entries=None)
+    # Deprecated API call (remove this test when we drop support for this)
+    req = api.post_invite_accepted(invitee_id='john.smith@gmail.com')
+    assert json.loads(req.body) == {'entries': [{
+        'email': 'john.smith@gmail.com',
+    }]}
+
+
+def test_endpoint_post_invite_accepted_advanced(api):
+    # Invocation with advanced (optional params)
+    now = datetime(2015, 3, 19, 13, 37, 00)
+    req = api.post_invite_accepted(phone='555-123000',
+                                   accepted_at=now, new_user_id=42)
+
+    assert req.method == 'POST'
+    assert req.url == 'https://api.yesgraph.com/v0/invites-accepted'
+
+    assert json.loads(req.body) == {'entries': [{
+        'accepted_at': '2015-03-19T13:37:00',
+        'phone': '555-123000',
+        'new_user_id': '42',
+    }]}
+
+    # Deprecated API call (remove this test when we drop support for this)
+    req = api.post_invite_accepted(invitee_id='555-123000', invitee_type='phone',
+                                   accepted_at=now, new_user_id=42)
+
+    assert json.loads(req.body) == {'entries': [{
+        'accepted_at': '2015-03-19T13:37:00',
+        'phone': '555-123000',
+        'new_user_id': '42',
+    }]}
 
 
 def test_endpoint_post_users(api):


### PR DESCRIPTION
#### What’s this PR do?
This is a hot fix to add invite-accepted and invite-sent back in, along with their tests, for backwards compatibility.

#### Where should the reviewer start?
Review the endpoints that were added back in.


#### Are there any DB migrations or updates?


#### How should this be manually tested?
We should manually test invite-sent and invite-accepted endpoints to make sure they work with this SDK.

#### Any background context you want to provide?

