### PR TITLE
Add Backfill Address-Books Endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.6.2
+- Adds POST /backfill/address-book endpoint for POSTing address-books without returning ranked results
+
 0.6.1
 - Adds POST /invite-sent (single entry) and POST /invite-accepted (single entry) deprecated endpoints back in for compatibility
 - Updates tests

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -116,6 +116,34 @@ def test_endpoint_post_address_book(api):
         {'name': 'Foo', 'email': 'foo@example.org'},
         {'name': 'Bar', 'email': 'bar@example.org'},
     ]
+    req = api.backfill_address_book(user_id=1234, entries=ENTRIES, source_type='gmail', limit=20)
+    assert req.method == 'POST'
+    assert req.url == 'https://api.yesgraph.com/v0/backfill/address-book'
+
+    assert json.loads(req.body) == {
+        'user_id': '1234',
+        'source': {'type': 'gmail'},
+        'entries': ENTRIES,
+    }
+
+    req = api.backfill_address_book(user_id=1234, entries=ENTRIES, source_type='gmail',
+                                filter_suggested_seen=1, limit=20)
+    assert req.method == 'POST'
+    assert req.url == 'https://api.yesgraph.com/v0/backfill/address-book'
+
+    assert json.loads(req.body) == {
+        'user_id': '1234',
+        'source': {'type': 'gmail'},
+        'entries': ENTRIES,
+    }
+
+
+def test_endpoint_post_address_book(api):
+    # Simplest invocation (without source info)
+    ENTRIES = [
+        {'name': 'Foo', 'email': 'foo@example.org'},
+        {'name': 'Bar', 'email': 'bar@example.org'},
+    ]
     req = api.post_address_book(user_id=1234, entries=ENTRIES, source_type='gmail', limit=20)
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/address-book'

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -166,6 +166,33 @@ class YesGraphAPI(object):
 
         return self._request('POST', '/address-book', data)
 
+
+    def backfill_address_book(self, user_id, entries, source_type, source_name=None,
+                          source_email=None):
+        """
+        Wrapped method for POST of /address-book endpoint
+
+        Documentation - https://www.yesgraph.com/docs/address-book
+        """
+        source = {
+            'type': source_type,
+        }
+        if source_name:
+            source['name'] = source_name
+        if source_email:
+            source['email'] = source_email
+
+        data = {
+            'user_id': str(user_id),
+            'source': source,
+            'entries': entries,
+        }
+
+        data = json.dumps(data)
+
+        return self._request('POST', '/backfill/address-book', data)
+
+
     def post_invites_accepted(self, **kwargs):
         """
         Wrapped method for POST of /invites-accepted endpoint

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -9,7 +9,7 @@ from requests import Request, Session
 
 from six.moves.urllib.parse import quote_plus
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 
 
 def deprecation(message):


### PR DESCRIPTION
This adds an endpoint to enable POSTing address-books to YesGraph without receiving ranked results. This is for faster backfill of data into YesGraph without taxing the servers.