### PR TITLE
Fix to getting client key via YesGraph API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.6.3
+- Removes the GET /followers/<type>/<identifier> endpoint
+- Fixes the GET /client-key/ endpoint to work with requests version 2.8
+
 0.6.2
 - Adds POST /backfill/address-book endpoint for POSTing address-books without returning ranked results
 

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -96,7 +96,7 @@ def test_endpoint_get_client_key(api):
     req = api._get_client_key(user_id=1234)
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/client-key'
-    assert req.body == 'user_id=1234'
+    assert req.body == '{"user_id": "1234"}'
 
 
 def test_endpoint_get_address_book(api):
@@ -110,13 +110,13 @@ def test_endpoint_get_address_book(api):
     assert req.url == 'https://api.yesgraph.com/v0/address-book/user%2Fwith%3Funsafe%26chars%3Dinthem'
 
 
-def test_endpoint_post_address_book(api):
+def test_endpoint_backfill_address_book(api):
     # Simplest invocation (without source info)
     ENTRIES = [
         {'name': 'Foo', 'email': 'foo@example.org'},
         {'name': 'Bar', 'email': 'bar@example.org'},
     ]
-    req = api.backfill_address_book(user_id=1234, entries=ENTRIES, source_type='gmail', limit=20)
+    req = api.backfill_address_book(user_id=1234, entries=ENTRIES, source_type='gmail')
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/backfill/address-book'
 
@@ -126,8 +126,7 @@ def test_endpoint_post_address_book(api):
         'entries': ENTRIES,
     }
 
-    req = api.backfill_address_book(user_id=1234, entries=ENTRIES, source_type='gmail',
-                                filter_suggested_seen=1, limit=20)
+    req = api.backfill_address_book(user_id=1234, entries=ENTRIES, source_type='gmail')
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/backfill/address-book'
 
@@ -371,29 +370,6 @@ def test_endpoint_post_users(api):
     assert req.url == 'https://api.yesgraph.com/v0/users'
 
     assert json.loads(req.body) == USERS
-
-
-def test_endpoint_get_followers(api):
-    user_id = "1234"
-    email = "email@email.com"
-    phone = "555-111-2222"
-
-    req = api.get_followers(type_name='user_id', identifier=user_id)
-    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}'.format('user_id', user_id)
-    req = api.get_followers(type_name='email', identifier=email)
-    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}'.format('email', email)
-    req = api.get_followers(type_name='phone', identifier=phone)
-    assert req.url == 'https://api.yesgraph.com/v0/followers/{0}/{1}'.format('phone', phone)
-    assert req.method == 'GET'
-
-    with pytest.raises(ValueError):
-        req = api.get_followers(type_name='some_wrong_type', identifier=email)
-    with pytest.raises(ValueError):
-        req = api.get_followers(type_name='some_wrong_type2', identifier=email)
-    with pytest.raises(ValueError):
-        req = api.get_followers(type_name='email', identifier=None)
-    with pytest.raises(ValueError):
-        req = api.get_followers(type_name='phone', identifier=None)
 
 
 def test_response_success(api):

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -100,7 +100,8 @@ class YesGraphAPI(object):
         return self._request('GET', '/test')
 
     def _get_client_key(self, user_id):
-        return self._request('POST', '/client-key', {'user_id': str(user_id)})
+        data = json.dumps({'user_id': str(user_id)})
+        return self._request('POST', '/client-key', data)
 
     def get_client_key(self, user_id):
         """
@@ -166,9 +167,8 @@ class YesGraphAPI(object):
 
         return self._request('POST', '/address-book', data)
 
-
     def backfill_address_book(self, user_id, entries, source_type, source_name=None,
-                          source_email=None):
+                              source_email=None):
         """
         Wrapped method for POST of /address-book endpoint
 
@@ -191,7 +191,6 @@ class YesGraphAPI(object):
         data = json.dumps(data)
 
         return self._request('POST', '/backfill/address-book', data)
-
 
     def post_invites_accepted(self, **kwargs):
         """
@@ -343,18 +342,3 @@ class YesGraphAPI(object):
         data = json.dumps(users)
 
         return self._request('POST', '/users', data=data)
-
-    def get_followers(self, type_name, identifier):
-        """
-        Wrapped method for GET of /followers/<type>/<identifier>/
-
-        Documentation - https://docs.yesgraph.com/v0/docs/followerstypeidentifier
-        """
-        if type_name not in ['user_id', 'email', 'phone']:
-            raise ValueError("type_name must be 'user_id', 'email', or 'phone'")
-        if not identifier:
-            raise ValueError("Must have a non-null identifier")
-
-        endpoint = '/followers/{0}/{1}'.format(type_name, identifier)
-
-        return self._request('GET', endpoint)

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -9,7 +9,7 @@ from requests import Request, Session
 
 from six.moves.urllib.parse import quote_plus
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 
 def deprecation(message):


### PR DESCRIPTION
This PR makes a few changes:

* Removes the GET `/followers/` endpoint
* Fixes the GET `/client-key/` endpoint to work with requests version 2.8

## Testing

Run `tox`
