### PR TITLE
Adding /alias endpoint and unit test

### DIFF
--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -372,6 +372,20 @@ def test_endpoint_post_users(api):
     assert json.loads(req.body) == USERS
 
 
+def test_endpoint_post_alias(api):
+    data = {'entries': [
+        {'emails': ['john.smith@gmail.com']},
+        {'emails': ['jane.doe@gmail.com']},
+    ]}
+
+    req = api.post_alias(entries=data['entries'])
+
+    assert req.method == 'POST'
+    assert req.url == 'https://api.yesgraph.com/v0/alias'
+
+    assert json.loads(req.body) == data
+
+
 def test_response_success(api):
     fake_http_response = make_fake_response(200, {
         'meta': {

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -342,3 +342,21 @@ class YesGraphAPI(object):
         data = json.dumps(users)
 
         return self._request('POST', '/users', data=data)
+
+    def post_alias(self, **kwargs):
+        """
+        Wrapped method for POST of /invites-accepted endpoint
+
+        Documentation - https://docs.yesgraph.com/docs/alias
+        """
+
+        entries = kwargs.get('entries', None)
+
+        if entries and type(entries) == list:
+            data = {'entries': entries}
+        else:
+            raise ValueError('An entry list is required')
+
+        data = json.dumps(data)
+
+        return self._request('POST', '/alias', data)


### PR DESCRIPTION
This PR adds the /alias endpoint to the SDK so we can access the API. This allows the user to get a list of alias emails given a list of emails. So for example, if you want to find the other emails for a user for whom you have their gmail, you can use this API.

More documentation for the endpoint is available here:
https://docs.yesgraph.com/docs/alias