### PR TITLE
Update to /alias and /domain-emails/ endpoints

### DIFF
--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -373,12 +373,9 @@ def test_endpoint_post_users(api):
 
 
 def test_endpoint_post_alias(api):
-    data = {'entries': [
-        {'emails': ['john.smith@gmail.com']},
-        {'emails': ['jane.doe@gmail.com']},
-    ]}
+    data = {'emails': ['john.smith@gmail.com', 'jane.doe@gmail.com']}
 
-    req = api.post_alias(entries=data['entries'])
+    req = api.post_alias(emails=data['emails'])
 
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/alias'

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -110,6 +110,13 @@ def test_endpoint_get_address_book(api):
     assert req.url == 'https://api.yesgraph.com/v0/address-book/user%2Fwith%3Funsafe%26chars%3Dinthem'
 
 
+def test_endpoint_get_domain_emails(api):
+    req = api.get_domain_emails(domain='yesgraph.com')
+    assert req.method == 'GET'
+    assert req.url == 'https://api.yesgraph.com/v0/domain-emails/yesgraph.com'
+    assert req.body is None
+
+
 def test_endpoint_backfill_address_book(api):
     # Simplest invocation (without source info)
     ENTRIES = [

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -52,11 +52,7 @@ class YesGraphAPI(object):
 
         return url
 
-    def _prepare_request(self, method, endpoint, data=None,
-                         filter_suggested_seen=None,
-                         filter_existing_users=None,
-                         filter_invites_sent=None,
-                         promote_existing_users=None, limit=None):
+    def _prepare_request(self, method, endpoint, data=None, **url_args):
         """Builds and prepares the complete request, but does not send it."""
         headers = {
             'Authorization': 'Bearer {0}'.format(self.secret_key),
@@ -64,11 +60,7 @@ class YesGraphAPI(object):
             'User-Agent': self.user_agent,
         }
 
-        url = self._build_url(endpoint, filter_suggested_seen=filter_suggested_seen,
-                              filter_existing_users=filter_existing_users,
-                              filter_invites_sent=filter_invites_sent,
-                              promote_existing_users=promote_existing_users,
-                              limit=limit)
+        url = self._build_url(endpoint, **url_args)
 
         req = Request(method, url, data=data, headers=headers)
 
@@ -131,14 +123,17 @@ class YesGraphAPI(object):
         endpoint = '/address-book/{0}'.format(quote_plus(str(user_id)))
         return self._request('GET', endpoint, **urlargs)
 
-    def get_domain_emails(self, domain):
+    def get_domain_emails(self, domain, page=None, batch_size=None):
         """
         Wrapped method for GET of /domain-emails/<domain> endpoint
 
         Documentation - https://docs.yesgraph.com/docs/domain-emails/
         """
+
+        urlargs = {'page': page, 'batch_size': batch_size}
+
         endpoint = '/domain-emails/{0}'.format(quote_plus(str(domain)))
-        return self._request('GET', endpoint)
+        return self._request('GET', endpoint, **urlargs)
 
     def post_address_book(self, user_id, entries, source_type, source_name=None,
                           source_email=None, filter_suggested_seen=None,

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -350,10 +350,10 @@ class YesGraphAPI(object):
         Documentation - https://docs.yesgraph.com/docs/alias
         """
 
-        entries = kwargs.get('entries', None)
+        emails = kwargs.get('emails', None)
 
-        if entries and type(entries) == list:
-            data = {'entries': entries}
+        if emails and type(emails) == list:
+            data = {'emails': emails}
         else:
             raise ValueError('An entry list is required')
 

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -133,9 +133,9 @@ class YesGraphAPI(object):
 
     def get_domain_emails(self, domain):
         """
-        Wrapped method for POST of /client-key endpoint
+        Wrapped method for GET of /domain-emails/<domain> endpoint
 
-        Documentation - https://docs.yesgraph.com/docs/create-client-keys
+        Documentation - https://docs.yesgraph.com/docs/domain-emails/
         """
         endpoint = '/domain-emails/{0}'.format(quote_plus(str(domain)))
         return self._request('GET', endpoint)
@@ -179,9 +179,9 @@ class YesGraphAPI(object):
     def backfill_address_book(self, user_id, entries, source_type, source_name=None,
                               source_email=None):
         """
-        Wrapped method for POST of /address-book endpoint
+        Wrapped method for POST of /backfill/address-book endpoint
 
-        Documentation - https://www.yesgraph.com/docs/address-book
+        Documentation - https://www.yesgraph.com/docs/backfill/address-book
         """
         source = {
             'type': source_type,
@@ -223,7 +223,7 @@ class YesGraphAPI(object):
         """
         Wrapped method for POST of /invite-accepted endpoint
 
-        Documentation - https://www.yesgraph.com/docs/reference#post-invite-accepted
+        Documentation - https://docs.yesgraph.com/docs/invites-accepted
         """
         email = kwargs.get('email')
         phone = kwargs.get('phone')
@@ -284,7 +284,7 @@ class YesGraphAPI(object):
         """
         Wrapped method for POST of /invite-sent endpoint
 
-        Documentation - https://www.yesgraph.com/docs/reference#post-invite-sent
+        Documentation - https://docs.yesgraph.com/docs/invites-sent
         """
         email = kwargs.get('email')
         phone = kwargs.get('phone')
@@ -325,7 +325,7 @@ class YesGraphAPI(object):
 
     def post_suggested_seen(self, **kwargs):
         """
-        Wrapped method for POST of /invites-accepted endpoint
+        Wrapped method for POST of /suggested-seen endpoint
 
         Documentation - https://docs.yesgraph.com/docs/suggested-seen
         """
@@ -354,7 +354,7 @@ class YesGraphAPI(object):
 
     def post_alias(self, **kwargs):
         """
-        Wrapped method for POST of /invites-accepted endpoint
+        Wrapped method for POST of /alias endpoint
 
         Documentation - https://docs.yesgraph.com/docs/alias
         """

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -131,6 +131,15 @@ class YesGraphAPI(object):
         endpoint = '/address-book/{0}'.format(quote_plus(str(user_id)))
         return self._request('GET', endpoint, **urlargs)
 
+    def get_domain_emails(self, domain):
+        """
+        Wrapped method for POST of /client-key endpoint
+
+        Documentation - https://docs.yesgraph.com/docs/create-client-keys
+        """
+        endpoint = '/domain-emails/{0}'.format(quote_plus(str(domain)))
+        return self._request('GET', endpoint)
+
     def post_address_book(self, user_id, entries, source_type, source_name=None,
                           source_email=None, filter_suggested_seen=None,
                           filter_existing_users=None,


### PR DESCRIPTION
This updates the alias endpoint to take in just the list of emails like this:
```
{'emails': ['john.smith@gmail.com', 'jane.doe@gmail.com']}
```
and include in the output the user_ids associated with any emails. Updates are documented here:
https://docs.yesgraph.com/docs/alias

This also adds a method get_domain_emails to GET the /domain-emails/<domain> endpoint.
