### PR TITLE
remove the address-book backfill endpoint, merge it with post addressbook

### DIFF
--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -128,33 +128,6 @@ def test_endpoint_get_domain_emails(api):
     assert req.body is None
 
 
-def test_endpoint_backfill_address_book(api):
-    # Simplest invocation (without source info)
-    ENTRIES = [
-        {'name': 'Foo', 'email': 'foo@example.org'},
-        {'name': 'Bar', 'email': 'bar@example.org'},
-    ]
-    req = api.backfill_address_book(user_id=1234, entries=ENTRIES, source_type='gmail')
-    assert req.method == 'POST'
-    assert req.url == 'https://api.yesgraph.com/v0/backfill/address-book'
-
-    assert json.loads(req.body) == {
-        'user_id': '1234',
-        'source': {'type': 'gmail'},
-        'entries': ENTRIES,
-    }
-
-    req = api.backfill_address_book(user_id=1234, entries=ENTRIES, source_type='gmail')
-    assert req.method == 'POST'
-    assert req.url == 'https://api.yesgraph.com/v0/backfill/address-book'
-
-    assert json.loads(req.body) == {
-        'user_id': '1234',
-        'source': {'type': 'gmail'},
-        'entries': ENTRIES,
-    }
-
-
 def test_endpoint_post_address_book(api):
     # Simplest invocation (without source info)
     ENTRIES = [
@@ -175,7 +148,8 @@ def test_endpoint_post_address_book(api):
         'promote_existing_users': None,
         'promote_matching_domain': None,
         'entries': ENTRIES,
-        'limit': 20
+        'limit': 20,
+        'backfill': None
     }
 
     req = api.post_address_book(user_id=1234, entries=ENTRIES, source_type='gmail',
@@ -193,7 +167,8 @@ def test_endpoint_post_address_book(api):
         'promote_existing_users': None,
         'promote_matching_domain': None,
         'entries': ENTRIES,
-        'limit': 20
+        'limit': 20,
+        'backfill': None
     }
 
 
@@ -218,7 +193,33 @@ def test_endpoint_post_address_book_with_source_info(api):
         'promote_existing_users': None,
         'promote_matching_domain': None,
         'entries': ENTRIES,
-        'limit': None
+        'limit': None,
+        'backfill': None
+    }
+
+
+def test_endpoint_post_address_book_backfill(api):
+    # Simplest invocation (without source info)
+    ENTRIES = [
+        {'name': 'Foo', 'email': 'foo@example.org'},
+        {'name': 'Bar', 'email': 'bar@example.org'},
+    ]
+    req = api.post_address_book(user_id=1234, entries=ENTRIES, source_type='gmail', backfill=True)
+    assert req.method == 'POST'
+    assert req.url == 'https://api.yesgraph.com/v0/address-book'
+    print(json.loads(req.body))
+    assert json.loads(req.body) == {
+        'user_id': '1234',
+        'source': {'type': 'gmail'},
+        'filter_suggested_seen': None,
+        'filter_existing_users': None,
+        'filter_invites_sent': None,
+        'filter_blank_names': None,
+        'promote_existing_users': None,
+        'promote_matching_domain': None,
+        'entries': ENTRIES,
+        'limit': None,
+        'backfill': True
     }
 
 

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -204,7 +204,7 @@ def test_endpoint_post_address_book_backfill(api):
         {'name': 'Foo', 'email': 'foo@example.org'},
         {'name': 'Bar', 'email': 'bar@example.org'},
     ]
-    req = api.post_address_book(user_id=1234, entries=ENTRIES, source_type='gmail', backfill=True)
+    req = api.post_address_book(user_id=1234, entries=ENTRIES, source_type='gmail', backfill=1)
     assert req.method == 'POST'
     assert req.url == 'https://api.yesgraph.com/v0/address-book'
     print(json.loads(req.body))

--- a/tests/test_yesgraph.py
+++ b/tests/test_yesgraph.py
@@ -219,7 +219,7 @@ def test_endpoint_post_address_book_backfill(api):
         'promote_matching_domain': None,
         'entries': ENTRIES,
         'limit': None,
-        'backfill': True
+        'backfill': 1
     }
 
 

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -9,7 +9,7 @@ from requests import Request, Session
 
 from six.moves.urllib.parse import quote_plus
 
-__version__ = '0.6.5'
+__version__ = '0.6.6'
 
 
 def deprecation(message):

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -111,6 +111,7 @@ class YesGraphAPI(object):
                           filter_blank_names=None,
                           promote_existing_users=None,
                           promote_matching_domain=None,
+                          backfill=None,
                           limit=None):
         """
         Wrapped method for POST of /address-book endpoint
@@ -128,6 +129,9 @@ class YesGraphAPI(object):
         if limit is not None:
             assert(type(limit) == int)
 
+        if backfill is not None:
+            assert(type(backfill) == bool)
+
         data = {
             'user_id': str(user_id),
             'filter_suggested_seen': filter_suggested_seen,
@@ -138,37 +142,13 @@ class YesGraphAPI(object):
             'promote_matching_domain': promote_matching_domain,
             'source': source,
             'entries': entries,
-            'limit': limit
+            'limit': limit,
+            'backfill': backfill
         }
 
         data = json.dumps(data)
 
         return self._request('POST', '/address-book', data)
-
-    def backfill_address_book(self, user_id, entries, source_type, source_name=None,
-                              source_email=None):
-        """
-        Wrapped method for POST of /backfill/address-book endpoint
-
-        Documentation - https://docs.yesgraph.com/docs/backfilladdress-book
-        """
-        source = {
-            'type': source_type,
-        }
-        if source_name:
-            source['name'] = source_name
-        if source_email:
-            source['email'] = source_email
-
-        data = {
-            'user_id': str(user_id),
-            'source': source,
-            'entries': entries,
-        }
-
-        data = json.dumps(data)
-
-        return self._request('POST', '/backfill/address-book', data)
 
     def get_address_book(self, user_id, filter_suggested_seen=None,
                          filter_existing_users=None,

--- a/yesgraph.py
+++ b/yesgraph.py
@@ -130,7 +130,7 @@ class YesGraphAPI(object):
             assert(type(limit) == int)
 
         if backfill is not None:
-            assert(type(backfill) == bool)
+            assert(type(backfill) == int)
 
         data = {
             'user_id': str(user_id),


### PR DESCRIPTION
This PR removes the method `backfill_address_book` for backfilling address-books. Backfill is now a flag on the `post_address_book` method.

Documentation is available at: https://docs.yesgraph.com/docs/address-book